### PR TITLE
Fix XR timing backpressure and stats leaks

### DIFF
--- a/js/performance-tracker.js
+++ b/js/performance-tracker.js
@@ -16,7 +16,7 @@ export class PerformanceEntry {
         this.buffer = new Array(bufferLength);
     }
     addSample(value) {
-        this.#lastBufferIndex = (this.#lastBufferIndex + 1 % this.buffer.length);
+        this.#lastBufferIndex = (this.#lastBufferIndex + 1) % this.buffer.length;
         this.buffer[this.#lastBufferIndex] = value;
     }
     get latest() {

--- a/js/webgpu-renderer/timestamp-helper.js
+++ b/js/webgpu-renderer/timestamp-helper.js
@@ -12,6 +12,7 @@ export class TimestampHelper {
     #timestampReadbackBuffers = [];
     #readbackBufferCount = 0;
     #currentReadbackBuffer = null;
+    #readbackPromise = null;
     #passTimings = new Map();
     #maxPassCount = 0;
     #nextQueryIndex = 0;
@@ -40,11 +41,11 @@ export class TimestampHelper {
         if (!this.#timestampsSupported) {
             return undefined;
         }
-        if (this.#currentReadbackBuffer) {
-            throw new Error('Must read back the previous resolve before new timestampes can be added.');
+        if (this.#currentReadbackBuffer || this.#readbackPromise) {
+            return undefined;
         }
         if (this.#nextQueryIndex >= this.#maxPassCount * 2) {
-            throw new Error('Exceeded the number of passes that can be queried in a single resolve.');
+            return undefined;
         }
         const timestampWrites = {
             querySet: this.#timestampQuerySet,
@@ -60,10 +61,10 @@ export class TimestampHelper {
     }
     resolve(commandEncoder) {
         if (!this.#timestampsSupported) {
-            return;
+            return false;
         }
-        if (this.#currentReadbackBuffer) {
-            throw new Error('Must read back the previous resolve before resolve can be called again.');
+        if (this.#currentReadbackBuffer || this.#readbackPromise || this.#nextQueryIndex == 0) {
+            return false;
         }
         if (this.#timestampReadbackBuffers.length > 0) {
             this.#currentReadbackBuffer = this.#timestampReadbackBuffers.pop();
@@ -78,67 +79,81 @@ export class TimestampHelper {
         }
         commandEncoder.resolveQuerySet(this.#timestampQuerySet, 0, this.#nextQueryIndex, this.#timestampResolveBuffer, 0);
         commandEncoder.copyBufferToBuffer(this.#timestampResolveBuffer, 0, this.#currentReadbackBuffer, 0, this.#timestampResolveBuffer.size);
+        return true;
     }
     async read() {
+        if (this.#readbackPromise) {
+            return this.#readbackPromise;
+        }
         if (!this.#currentReadbackBuffer) {
             return;
         }
         let readbackBuffer = this.#currentReadbackBuffer;
         let queries = new Map(this.#queriesUsed);
-        this.#currentReadbackBuffer = null;
         this.#queriesUsed.clear();
         this.#nextQueryIndex = 0;
-        await readbackBuffer.mapAsync(GPUMapMode.READ);
-        const mappedArray = new BigUint64Array(readbackBuffer.getMappedRange());
-        const results = {};
-        for (const [name, query] of queries.entries()) {
-            const passTime = Number(mappedArray[query.end] - mappedArray[query.begin]);
-            // Discard negative times
-            if (passTime >= 0) {
-                let passTimings = this.#passTimings.get(name);
-                if (!passTimings) {
-                    passTimings = {
-                        values: new Array(AVG_SAMPLE_COUNT),
-                        index: 0,
-                    };
-                    this.#passTimings.set(name, passTimings);
-                }
-                // Storing pass timings in µs
-                let passTimeMicro = passTime / 1000;
-                passTimings.values[passTimings.index++ % AVG_SAMPLE_COUNT] = passTimeMicro;
-                if (passTimings.index % AVG_SAMPLE_COUNT == 0) {
-                    // Update the average
-                    let avg = 0;
-                    for (const value of passTimings.values) {
-                        avg += value;
+        this.#readbackPromise = (async () => {
+            await readbackBuffer.mapAsync(GPUMapMode.READ);
+            const mappedArray = new BigUint64Array(readbackBuffer.getMappedRange());
+            const results = {};
+            for (const [name, query] of queries.entries()) {
+                const passTime = Number(mappedArray[query.end] - mappedArray[query.begin]);
+                // Discard negative times
+                if (passTime >= 0) {
+                    let passTimings = this.#passTimings.get(name);
+                    if (!passTimings) {
+                        passTimings = {
+                            values: new Array(AVG_SAMPLE_COUNT),
+                            index: 0,
+                        };
+                        this.#passTimings.set(name, passTimings);
                     }
-                    this.#averages[name] = avg / AVG_SAMPLE_COUNT;
-                }
-                results[name] = passTimeMicro;
-            }
-        }
-        // Update any existing keys not in the queries to 0. This way if one of them
-        // isn't present in the readback it will zero out instead of appearing to
-        // stay steady at the last reading.
-        for (const name of this.#passTimings.keys()) {
-            if (!queries.has(name)) {
-                let passTimings = this.#passTimings.get(name);
-                passTimings.values[passTimings.index++ % AVG_SAMPLE_COUNT] = 0;
-                if (passTimings.index % AVG_SAMPLE_COUNT == 0) {
-                    // Update the average
-                    let avg = 0;
-                    for (const value of passTimings.values) {
-                        avg += value;
+                    // Storing pass timings in µs
+                    let passTimeMicro = passTime / 1000;
+                    passTimings.values[passTimings.index++ % AVG_SAMPLE_COUNT] = passTimeMicro;
+                    if (passTimings.index % AVG_SAMPLE_COUNT == 0) {
+                        // Update the average
+                        let avg = 0;
+                        for (const value of passTimings.values) {
+                            avg += value;
+                        }
+                        this.#averages[name] = avg / AVG_SAMPLE_COUNT;
                     }
-                    this.#averages[name] = avg / AVG_SAMPLE_COUNT;
+                    results[name] = passTimeMicro;
                 }
             }
+            // Update any existing keys not in the queries to 0. This way if one of them
+            // isn't present in the readback it will zero out instead of appearing to
+            // stay steady at the last reading.
+            for (const name of this.#passTimings.keys()) {
+                if (!queries.has(name)) {
+                    let passTimings = this.#passTimings.get(name);
+                    passTimings.values[passTimings.index++ % AVG_SAMPLE_COUNT] = 0;
+                    if (passTimings.index % AVG_SAMPLE_COUNT == 0) {
+                        // Update the average
+                        let avg = 0;
+                        for (const value of passTimings.values) {
+                            avg += value;
+                        }
+                        this.#averages[name] = avg / AVG_SAMPLE_COUNT;
+                    }
+                }
+            }
+            readbackBuffer.unmap();
+            this.#timestampReadbackBuffers.push(readbackBuffer);
+            return results;
+        })();
+        try {
+            return await this.#readbackPromise;
         }
-        readbackBuffer.unmap();
-        this.#timestampReadbackBuffers.push(readbackBuffer);
-        return results;
+        finally {
+            if (this.#currentReadbackBuffer === readbackBuffer) {
+                this.#currentReadbackBuffer = null;
+            }
+            this.#readbackPromise = null;
+        }
     }
-    hasPendingResults() { return this.#nextQueryIndex != 0; }
+    hasPendingResults() { return this.#nextQueryIndex != 0 || !!this.#currentReadbackBuffer || !!this.#readbackPromise; }
     get averages() {
         return this.#averages;
     }

--- a/js/webgpu-renderer/webgpu-renderer.js
+++ b/js/webgpu-renderer/webgpu-renderer.js
@@ -372,16 +372,19 @@ export class WebGPURenderer extends Renderer {
 
     passEncoder.end();
 
-    this.timestampHelper.resolve(commandEncoder);
+    const didResolveTimestamps = this.timestampHelper.resolve(commandEncoder);
 
     const commandBuffer = commandEncoder.finish();
     this.device.queue.submit([commandBuffer]);
 
-    this.timestampHelper.read().then((results) => {
-      for (let [key, result] of Object.entries(results)) {
-        this.stats.addSample(key, result);
-      }
-    });
+    if (didResolveTimestamps) {
+      this.timestampHelper.read().then((results) => {
+        if (!results || !this.stats) { return; }
+        for (let [key, result] of Object.entries(results)) {
+          this.stats.addSample(key, result);
+        }
+      });
+    }
   }
 
   async onXRStarted(options) {
@@ -482,15 +485,18 @@ export class WebGPURenderer extends Renderer {
       renderPass.end();
     }
 
-    this.timestampHelper.resolve(commandEncoder);
+    const didResolveTimestamps = this.timestampHelper.resolve(commandEncoder);
 
     const commandBuffer = commandEncoder.finish();
     this.device.queue.submit([commandBuffer]);
 
-    this.timestampHelper.read().then((results) => {
-      for (let [key, result] of Object.entries(results)) {
-        this.stats.addSample(key, result);
-      }
-    });
+    if (didResolveTimestamps) {
+      this.timestampHelper.read().then((results) => {
+        if (!results || !this.stats) { return; }
+        for (let [key, result] of Object.entries(results)) {
+          this.stats.addSample(key, result);
+        }
+      });
+    }
   }
 }

--- a/js/webgpu-renderer/webgpu-view.js
+++ b/js/webgpu-renderer/webgpu-view.js
@@ -67,46 +67,66 @@ export class WebGPUView {
 
     this.msaaTexture = null;
     this.msaaTextureView = null;
+    this.msaaTextureDescriptor = null;
     this.depthTexture = null;
     this.depthTextureView = null;
+    this.depthTextureDescriptor = null;
   }
 
   getMsaaTextureView(colorTexture, sampleCount) {
-    if (!this.msaaTexture || this.msaaTexture?.sampleCount != sampleCount,
-        this.msaaTexture?.format != colorTexture.format ||
-        this.msaaTexture?.width != colorTexture.width ||
-        this.msaaTexture?.height != colorTexture.height) {
+    const msaaTextureDescriptor = {
+      sampleCount,
+      format: colorTexture.format,
+      width: colorTexture.width,
+      height: colorTexture.height,
+    };
+    if (!this.msaaTexture ||
+        !this.msaaTextureDescriptor ||
+        this.msaaTextureDescriptor.sampleCount != msaaTextureDescriptor.sampleCount ||
+        this.msaaTextureDescriptor.format != msaaTextureDescriptor.format ||
+        this.msaaTextureDescriptor.width != msaaTextureDescriptor.width ||
+        this.msaaTextureDescriptor.height != msaaTextureDescriptor.height) {
       // Explicitly destroying previous textures when resizing helps avoid
       // Out of Memory errors on the GPU.
       if (this.msaaTexture) { this.msaaTexture.destroy(); }
       this.msaaTexture = this.renderer.device.createTexture({
         label: `MSAA, view.id:${this.id}`,
-        size: { width: colorTexture.width, height: colorTexture.height },
-        sampleCount,
-        format: colorTexture.format,
+        size: { width: msaaTextureDescriptor.width, height: msaaTextureDescriptor.height },
+        sampleCount: msaaTextureDescriptor.sampleCount,
+        format: msaaTextureDescriptor.format,
         usage: GPUTextureUsage.RENDER_ATTACHMENT,
       });
       this.msaaTextureView = this.msaaTexture.createView();
+      this.msaaTextureDescriptor = msaaTextureDescriptor;
     }
     return this.msaaTextureView;
   }
 
   getDepthTextureView(colorTexture, format, sampleCount) {
-    if (!this.depthTexture || this.depthTexture?.sampleCount != sampleCount,
-        this.depthTexture?.format != format ||
-        this.depthTexture?.width != colorTexture.width ||
-        this.depthTexture?.height != colorTexture.height) {
+    const depthTextureDescriptor = {
+      sampleCount,
+      format,
+      width: colorTexture.width,
+      height: colorTexture.height,
+    };
+    if (!this.depthTexture ||
+        !this.depthTextureDescriptor ||
+        this.depthTextureDescriptor.sampleCount != depthTextureDescriptor.sampleCount ||
+        this.depthTextureDescriptor.format != depthTextureDescriptor.format ||
+        this.depthTextureDescriptor.width != depthTextureDescriptor.width ||
+        this.depthTextureDescriptor.height != depthTextureDescriptor.height) {
       // Explicitly destroying previous textures when resizing helps avoid
       // Out of Memory errors on the GPU.
       if (this.depthTexture) { this.depthTexture.destroy(); }
       this.depthTexture = this.renderer.device.createTexture({
         label: `Depth, view.id:${this.id}`,
-        size: { width: colorTexture.width, height: colorTexture.height },
-        sampleCount,
-        format,
+        size: { width: depthTextureDescriptor.width, height: depthTextureDescriptor.height },
+        sampleCount: depthTextureDescriptor.sampleCount,
+        format: depthTextureDescriptor.format,
         usage: GPUTextureUsage.RENDER_ATTACHMENT,
       });
       this.depthTextureView = this.depthTexture.createView();
+      this.depthTextureDescriptor = depthTextureDescriptor;
     }
     return this.depthTextureView;
   }
@@ -143,11 +163,9 @@ export class WebGPUView {
     mat4.copy(this.projectionMatrix, xrView.projectionMatrix);
     mat4.invert(this.inverseProjectionMatrix, this.projectionMatrix);
     mat4.copy(this.viewMatrix, xrView.transform.inverse.matrix);
-    vec3.copy(this.cameraPosition, [
-      xrView.transform.position.x,
-      xrView.transform.position.y,
-      xrView.transform.position.z
-    ]);
+    this.cameraPosition[0] = xrView.transform.position.x;
+    this.cameraPosition[1] = xrView.transform.position.y;
+    this.cameraPosition[2] = xrView.transform.position.z;
 
     device.queue.writeBuffer(this.projectionBuffer, 0, this.uniformsArray.buffer, 0, ProjectionUniformsSize);
     device.queue.writeBuffer(this.viewBuffer, 0, this.uniformsArray.buffer, ProjectionUniformsSize, ViewUniformsSize);


### PR DESCRIPTION
Prevent the WebXR path from queuing unbounded timestamp readbacks while previous GPU timing results are still pending.

Also fix the performance sample ring buffer wraparound bug, only read timestamp results when a resolve was recorded, and correct the XR attachment cache checks in the view helper.

Generated by AI :-)